### PR TITLE
feat: oauth2 login redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# .env
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
+        "react-icons": "^5.5.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
@@ -7106,6 +7107,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
+    "react-icons": "^5.5.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,60 @@
+require('dotenv').config();
+const express = require('express');
+const axios = require('axios');
+const app = express();
+
+app.listen(3000, () => console.log('Server is listening on port 3000'));
+
+app.get('/', (req, res) => {
+    res.send('Hello, this is homepage!');
+  });
+
+  app.get('/api/login', async (req, res) => {
+	const discordAuthURL = process.env.GENERATE_URI;
+	res.redirect(discordAuthURL);
+  });
+
+  app.get('/oauth2/redirect', async (req, res) => {
+    const requestToken = req.query.code;
+    let tokenResponse, userResponse;
+	console.log(requestToken);
+	console.log('[DEBUG] client_id:', process.env.CLIENT_ID); // 실제 출력해서 확인!
+	console.log('[DEBUG] client_secret:', process.env.CLIENT_SECRET?.slice(0, 5), '...'); // 앞 몇 글자만!
+    try {
+        tokenResponse = await axios({
+			method: 'post',
+			url: 'https://discord.com/api/oauth2/token',
+			data: new URLSearchParams({
+			  client_id: process.env.CLIENT_ID,
+			  client_secret: process.env.CLIENT_SECRET, // 중요!
+			  grant_type: 'authorization_code',
+			  code: requestToken,
+			  redirect_uri: process.env.REDIRECT_URI,
+			  scope: 'identify',
+			}),
+			headers: {
+			  'Content-Type': 'application/x-www-form-urlencoded',
+			},
+		}) ;
+
+
+        const accessToken = tokenResponse.data.access_token;
+
+        // Use the access token to fetch the user's data from Discord API
+        userResponse = await axios.get('https://discordapp.com/api/users/@me', {
+            headers: {
+                authorization: `Bearer ${accessToken}`,
+            },
+        });
+
+    } catch (error) {
+		console.error('🔴 에러 발생:', error.response?.data || error.message);
+        console.error(`Error in getting token or user data from Discord API: ${error.message}`);
+        return res.status(500).send('Server Error');
+    }
+
+    console.log(userResponse.data); // This logs the user's data
+
+    // Then redirect the user back to your react app
+    res.redirect('http://localhost:8080');
+});

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -9,6 +9,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { FaDiscord } from 'react-icons/fa';
 
 const Login: React.FC = () => {
   const { isAuthenticated, login } = useAuth();
@@ -18,7 +19,9 @@ const Login: React.FC = () => {
   const [isLoggingIn, setIsLoggingIn] = useState(false);
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  
+
+  const redirectUri = import.meta.env.VITE_AUTH_REDIRECT_URI;
+
   // Get the intended destination or default to dashboard
   const from = location.state?.from?.pathname || '/dashboard';
   
@@ -105,6 +108,19 @@ const Login: React.FC = () => {
                 )}
               </Button>
             </form>
+            <div className="mt-4">
+            <Button
+                type="button"
+                variant="secondary"
+                className="w-full flex items-center justify-center gap-2"
+                onClick={() => {
+                    window.location.href = redirectUri;
+                }}
+                >
+                <FaDiscord className="h-4 w-4" />
+                Login with Discord
+                </Button>
+            </div>
           </CardContent>
           <CardFooter className="flex justify-center">
             <p className="text-xs text-center text-muted-foreground">


### PR DESCRIPTION
### ✨ Discord 로그인 기능 추가

**구현 내용**
	•	“Login with Discord” 버튼 추가
	•	Discord OAuth2 흐름에 따라 로그인 구현

**동작 시나리오**
	1.	프론트엔드에서 /api/login으로 GET 요청
	2.	백엔드는 Discord 인증 URI로 리다이렉트 → /oauth2/redirect
	3.	Discord에서 전달된 code를 사용해 access token 요청 및 처리

**기타**
	•	테스트용 Express 서버(server.js)에서 동작 확인
	•	프론트엔드에서 직접 code를 받아 백엔드에 전달하는 방식도 고려 가능